### PR TITLE
Enhance page animations

### DIFF
--- a/script.js
+++ b/script.js
@@ -40,3 +40,15 @@ Object.entries(data).forEach(([sectionName, posts]) => {
   section.appendChild(grid);
   main.appendChild(section);
 });
+
+// reveal cards on scroll
+const observer = new IntersectionObserver((entries, obs) => {
+  entries.forEach(entry => {
+    if (entry.isIntersecting) {
+      entry.target.classList.add('in-view');
+      obs.unobserve(entry.target);
+    }
+  });
+}, { threshold: 0.1 });
+
+document.querySelectorAll('.card').forEach(card => observer.observe(card));

--- a/styles.css
+++ b/styles.css
@@ -6,6 +6,10 @@
     box-sizing: border-box;
 }
 
+html {
+    scroll-behavior: smooth;
+}
+
 :root {
     --bg: #fafafa;
     --card-bg: #fff;
@@ -33,6 +37,7 @@ body {
     min-height: 100vh;
     display: flex;
     flex-direction: column;
+    animation: pageFade 0.6s ease-in-out;
 }
 
 a {
@@ -154,8 +159,15 @@ section h2::after {
     box-shadow: var(--shadow);
     display: flex;
     flex-direction: column;
-    transition: transform .3s ease, box-shadow .3s ease;
+    opacity: 0;
+    transform: translateY(20px);
+    transition: transform .3s ease, box-shadow .3s ease, opacity .6s ease;
     border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.card.in-view {
+    opacity: 1;
+    transform: translateY(0);
 }
 
 .card:hover {
@@ -199,6 +211,15 @@ footer {
     font-weight: 300;
     color: var(--text-muted);
     background-color: rgba(0, 0, 0, 0.4);
+}
+
+@keyframes pageFade {
+    from {
+        opacity: 0;
+    }
+    to {
+        opacity: 1;
+    }
 }
 
 /* Font import */


### PR DESCRIPTION
## Summary
- enable smooth scrolling across the site
- fade page body in on load
- animate post cards when they appear on screen using IntersectionObserver

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68415fb166988328a95341c8957215fd